### PR TITLE
runlint chilopoda lib issue

### DIFF
--- a/runlint
+++ b/runlint
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # running lint
-pylama src/lib/chilopoda, src/lib/chilopodaqt src/bin tests
+pylama src/lib/chilopoda src/lib/chilopodaqt src/bin tests


### PR DESCRIPTION
Fixed chilopoda lib name in runlint executable