### PR TITLE
AAC strict in ffmpeg

### DIFF
--- a/src/lib/chilopoda/Task/Video/ConvertVideo.py
+++ b/src/lib/chilopoda/Task/Video/ConvertVideo.py
@@ -9,7 +9,7 @@ class ConvertVideo(Task):
 
     __ffmpegExecutable = os.environ.get('CHILOPODA_FFMPEG_EXECUTABLE', 'ffmpeg')
     __defaultVideoArgs = "-vcodec h264 -pix_fmt yuvj420p"
-    __defaultAudioArgs = "-f lavfi -t 1 -i anullsrc=r=48000:cl=stereo -acodec aac"
+    __defaultAudioArgs = "-f lavfi -t 1 -i anullsrc=r=48000:cl=stereo -acodec aac -strict -2"
     __defaultBitRate = 115
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Adds the flag "-strict -2" to be able to use AAC that is marked as experimental in old ffmpeg versions.